### PR TITLE
refactor: use BaseBalancer struct to reduce duplicated code

### DIFF
--- a/balancer/base_balancer.go
+++ b/balancer/base_balancer.go
@@ -1,0 +1,45 @@
+package balancer
+
+import (
+	"sync"
+)
+
+type BaseBalancer struct {
+	sync.RWMutex
+	hosts []string
+}
+
+// Add new host to the balancer
+func (b *BaseBalancer) Add(host string) {
+	b.Lock()
+	defer b.Unlock()
+	for _, h := range b.hosts {
+		if h == host {
+			return
+		}
+	}
+	b.hosts = append(b.hosts, host)
+}
+
+// Remove new host from the balancer
+func (b *BaseBalancer) Remove(host string) {
+	b.Lock()
+	defer b.Unlock()
+	for i, h := range b.hosts {
+		if h == host {
+			b.hosts = append(b.hosts[:i], b.hosts[i+1:]...)
+			return
+		}
+	}
+}
+
+// Balance selects a suitable host according
+func (b *BaseBalancer) Balance(key string) (string, error) {
+	return "", nil
+}
+
+// Inc .
+func (b *BaseBalancer) Inc(_ string) {}
+
+// Done .
+func (b *BaseBalancer) Done(_ string) {}

--- a/balancer/consistent_hash.go
+++ b/balancer/consistent_hash.go
@@ -14,12 +14,15 @@ func init() {
 
 // Consistent refers to consistent hash
 type Consistent struct {
+	BaseBalancer
 	ch *consistent.Consistent
 }
 
 // NewConsistent create new Consistent balancer
 func NewConsistent(hosts []string) Balancer {
-	c := &Consistent{consistent.New()}
+	c := &Consistent{
+		ch: consistent.New(),
+	}
 	for _, h := range hosts {
 		c.ch.Add(h)
 	}
@@ -43,9 +46,3 @@ func (c *Consistent) Balance(key string) (string, error) {
 	}
 	return c.ch.Get(key)
 }
-
-// Inc .
-func (c *Consistent) Inc(_ string) {}
-
-// Done .
-func (c *Consistent) Done(_ string) {}

--- a/balancer/ip_hash.go
+++ b/balancer/ip_hash.go
@@ -6,7 +6,6 @@ package balancer
 
 import (
 	"hash/crc32"
-	"sync"
 )
 
 func init() {
@@ -15,36 +14,15 @@ func init() {
 
 // IPHash will choose a host based on the client's IP address
 type IPHash struct {
-	sync.RWMutex
-	hosts []string
+	BaseBalancer
 }
 
 // NewIPHash create new IPHash balancer
 func NewIPHash(hosts []string) Balancer {
-	return &IPHash{hosts: hosts}
-}
-
-// Add new host to the balancer
-func (r *IPHash) Add(host string) {
-	r.Lock()
-	defer r.Unlock()
-	for _, h := range r.hosts {
-		if h == host {
-			return
-		}
-	}
-	r.hosts = append(r.hosts, host)
-}
-
-// Remove new host from the balancer
-func (r *IPHash) Remove(host string) {
-	r.Lock()
-	defer r.Unlock()
-	for i, h := range r.hosts {
-		if h == host {
-			r.hosts = append(r.hosts[:i], r.hosts[i+1:]...)
-			return
-		}
+	return &IPHash{
+		BaseBalancer: BaseBalancer{
+			hosts: hosts,
+		},
 	}
 }
 
@@ -58,9 +36,3 @@ func (r *IPHash) Balance(key string) (string, error) {
 	value := crc32.ChecksumIEEE([]byte(key)) % uint32(len(r.hosts))
 	return r.hosts[value], nil
 }
-
-// Inc .
-func (r *IPHash) Inc(_ string) {}
-
-// Done .
-func (r *IPHash) Done(_ string) {}

--- a/balancer/ip_hash_test.go
+++ b/balancer/ip_hash_test.go
@@ -22,15 +22,23 @@ func TestNewIPHash_Add(t *testing.T) {
 			NewIPHash([]string{"http://127.0.0.1:1011",
 				"http://127.0.0.1:1012", "http://127.0.0.1:1013"}),
 			"http://127.0.0.1:1012",
-			&IPHash{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012", "http://127.0.0.1:1013"}},
+			&IPHash{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012", "http://127.0.0.1:1013"},
+				},
+			},
 		},
 		{
 			"test-2",
 			NewIPHash([]string{"http://127.0.0.1:1011", "http://127.0.0.1:1012"}),
 			"http://127.0.0.1:1013",
-			&IPHash{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012", "http://127.0.0.1:1013"}},
+			&IPHash{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012", "http://127.0.0.1:1013"},
+				},
+			},
 		},
 	}
 	for _, c := range cases {
@@ -54,13 +62,23 @@ func TestIPHash_Remove(t *testing.T) {
 			NewIPHash([]string{"http://127.0.0.1:1011",
 				"http://127.0.0.1:1012", "http://127.0.0.1:1013"}),
 			"http://127.0.0.1:1012",
-			&IPHash{hosts: []string{"http://127.0.0.1:1011", "http://127.0.0.1:1013"}},
+			&IPHash{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1013"},
+				},
+			},
 		},
 		{
 			"test-2",
 			NewIPHash([]string{"http://127.0.0.1:1011", "http://127.0.0.1:1012"}),
 			"http://127.0.0.1:1013",
-			&IPHash{hosts: []string{"http://127.0.0.1:1011", "http://127.0.0.1:1012"}},
+			&IPHash{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012"},
+				},
+			},
 		},
 	}
 	for _, c := range cases {

--- a/balancer/random.go
+++ b/balancer/random.go
@@ -6,7 +6,6 @@ package balancer
 
 import (
 	"math/rand"
-	"sync"
 	"time"
 )
 
@@ -16,37 +15,17 @@ func init() {
 
 // Random will randomly select a http server from the server
 type Random struct {
-	sync.RWMutex
-	hosts []string
-	rnd   *rand.Rand
+	BaseBalancer
+	rnd *rand.Rand
 }
 
 // NewRandom create new Random balancer
 func NewRandom(hosts []string) Balancer {
-	return &Random{hosts: hosts,
-		rnd: rand.New(rand.NewSource(time.Now().UnixNano()))}
-}
-
-// Add new host to the balancer
-func (r *Random) Add(host string) {
-	r.Lock()
-	defer r.Unlock()
-	for _, h := range r.hosts {
-		if h == host {
-			return
-		}
-	}
-	r.hosts = append(r.hosts, host)
-}
-
-// Remove new host from the balancer
-func (r *Random) Remove(host string) {
-	r.Lock()
-	defer r.Unlock()
-	for i, h := range r.hosts {
-		if h == host {
-			r.hosts = append(r.hosts[:i], r.hosts[i+1:]...)
-		}
+	return &Random{
+		BaseBalancer: BaseBalancer{
+			hosts: hosts,
+		},
+		rnd: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -59,9 +38,3 @@ func (r *Random) Balance(_ string) (string, error) {
 	}
 	return r.hosts[r.rnd.Intn(len(r.hosts))], nil
 }
-
-// Inc .
-func (r *Random) Inc(_ string) {}
-
-// Done .
-func (r *Random) Done(_ string) {}

--- a/balancer/random_test.go
+++ b/balancer/random_test.go
@@ -23,19 +23,39 @@ func TestRandom_Add(t *testing.T) {
 	}{
 		{
 			"test-1",
-			&Random{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012", "http://127.0.0.1:1013"}, rnd: rnd},
+			&Random{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012", "http://127.0.0.1:1013"},
+				},
+				rnd: rnd,
+			},
 			"http://127.0.0.1:1013",
-			&Random{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012", "http://127.0.0.1:1013"}, rnd: rnd},
+			&Random{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012", "http://127.0.0.1:1013"},
+				},
+				rnd: rnd,
+			},
 		},
 		{
 			"test-2",
-			&Random{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012"}, rnd: rnd},
+			&Random{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012"},
+				},
+				rnd: rnd,
+			},
 			"http://127.0.0.1:1012",
-			&Random{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012"}, rnd: rnd},
+			&Random{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012"},
+				},
+				rnd: rnd,
+			},
 		},
 	}
 	for _, c := range cases {
@@ -57,19 +77,39 @@ func TestRandom_Remove(t *testing.T) {
 	}{
 		{
 			"test-1",
-			&Random{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012", "http://127.0.0.1:1013"}, rnd: rnd},
+			&Random{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012", "http://127.0.0.1:1013"},
+				},
+				rnd: rnd,
+			},
 			"http://127.0.0.1:1013",
-			&Random{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012"}, rnd: rnd},
+			&Random{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012"},
+				},
+				rnd: rnd,
+			},
 		},
 		{
 			"test-2",
-			&Random{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012"}, rnd: rnd},
+			&Random{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012"},
+				},
+				rnd: rnd,
+			},
 			"http://127.0.0.1:1013",
-			&Random{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012"}, rnd: rnd},
+			&Random{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012"},
+				},
+				rnd: rnd,
+			},
 		},
 	}
 	for _, c := range cases {

--- a/balancer/round_robin.go
+++ b/balancer/round_robin.go
@@ -4,15 +4,10 @@
 
 package balancer
 
-import (
-	"sync"
-)
-
 //RoundRobin will select the server in turn from the server to proxy
 type RoundRobin struct {
-	sync.RWMutex
-	i     uint64
-	hosts []string
+	BaseBalancer
+	i uint64
 }
 
 func init() {
@@ -21,30 +16,11 @@ func init() {
 
 // NewRoundRobin create new RoundRobin balancer
 func NewRoundRobin(hosts []string) Balancer {
-	return &RoundRobin{i: 0, hosts: hosts}
-}
-
-// Add new host to the balancer
-func (r *RoundRobin) Add(host string) {
-	r.Lock()
-	defer r.Unlock()
-	for _, h := range r.hosts {
-		if h == host {
-			return
-		}
-	}
-	r.hosts = append(r.hosts, host)
-}
-
-// Remove new host from the balancer
-func (r *RoundRobin) Remove(host string) {
-	r.Lock()
-	defer r.Unlock()
-	for i, h := range r.hosts {
-		if h == host {
-			r.hosts = append(r.hosts[:i], r.hosts[i+1:]...)
-			return
-		}
+	return &RoundRobin{
+		i: 0,
+		BaseBalancer: BaseBalancer{
+			hosts: hosts,
+		},
 	}
 }
 
@@ -59,9 +35,3 @@ func (r *RoundRobin) Balance(_ string) (string, error) {
 	r.i++
 	return host, nil
 }
-
-// Inc .
-func (r *RoundRobin) Inc(_ string) {}
-
-// Done .
-func (r *RoundRobin) Done(_ string) {}

--- a/balancer/round_roubin_test.go
+++ b/balancer/round_roubin_test.go
@@ -23,16 +23,26 @@ func TestRoundRobin_Add(t *testing.T) {
 			NewRoundRobin([]string{"http://127.0.0.1:1011",
 				"http://127.0.0.1:1012", "http://127.0.0.1:1013"}),
 			"http://127.0.0.1:1013",
-			&RoundRobin{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012", "http://127.0.0.1:1013"}, i: 0},
+			&RoundRobin{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012", "http://127.0.0.1:1013"},
+				},
+				i: 0,
+			},
 		},
 		{
 			"test-2",
 			NewRoundRobin([]string{"http://127.0.0.1:1011",
 				"http://127.0.0.1:1012"}),
 			"http://127.0.0.1:1012",
-			&RoundRobin{hosts: []string{"http://127.0.0.1:1011",
-				"http://127.0.0.1:1012"}, i: 0},
+			&RoundRobin{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012"},
+				},
+				i: 0,
+			},
 		},
 	}
 	for _, c := range cases {
@@ -55,13 +65,22 @@ func TestRoundRobin_Remove(t *testing.T) {
 			"test-1",
 			NewRoundRobin([]string{"http://127.0.0.1:1011", "http://127.0.0.1:1012"}),
 			"http://127.0.0.1:1013",
-			&RoundRobin{hosts: []string{"http://127.0.0.1:1011", "http://127.0.0.1:1012"}},
+			&RoundRobin{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011",
+						"http://127.0.0.1:1012"},
+				},
+			},
 		},
 		{
 			"test-2",
 			NewRoundRobin([]string{"http://127.0.0.1:1011", "http://127.0.0.1:1012"}),
 			"http://127.0.0.1:1012",
-			&RoundRobin{hosts: []string{"http://127.0.0.1:1011"}},
+			&RoundRobin{
+				BaseBalancer: BaseBalancer{
+					hosts: []string{"http://127.0.0.1:1011"},
+				},
+			},
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Add a base struct to implement Balancer interface and all balancers extend it to reduce unnecessary code